### PR TITLE
make wayland default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,11 @@ LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DA
 LABEL maintainer="thelamer"
 
 # title
-ENV TITLE=Github-Desktop
+ENV TITLE=Github-Desktop \
+    NO_GAMEPAD=true \
+    NO_FULL=true \
+    SELKIES_DESKTOP=true \
+    PIXELFLUX_WAYLAND=true
 
 RUN \
   echo "**** add icon ****" && \
@@ -42,6 +46,9 @@ RUN \
     /tmp/codium.deb -L \
     "https://github.com/VSCodium/vscodium/releases/download/${CODIUM_VERSION}/codium_${CODIUM_VERSION}_amd64.deb" && \
   apt install --no-install-recommends -y /tmp/codium.deb && \
+  sed -i \
+    's:/usr/share/codium/codium:/usr/bin/codium:g' \
+    /usr/share/applications/codium.desktop && \
   echo "**** container tweaks ****" && \
   ln -s \
     /usr/bin/xfce4-terminal \
@@ -52,9 +59,24 @@ RUN \
   echo "**** cleanup ****" && \
   apt-get autoclean && \
   rm -rf \
+    /tmp/* \
+    /usr/share/applications/caja-autorun-software.desktop \
+    /usr/share/applications/caja-computer.desktop \
+    /usr/share/applications/caja.desktop \
+    /usr/share/applications/caja-file-management-properties.desktop \
+    /usr/share/applications/caja-folder-handler.desktop \
+    /usr/share/applications/caja-home.desktop \
+    /usr/share/applications/codium-url-handler.desktop \
+    /usr/share/applications/debian-uxterm.desktop \
+    /usr/share/applications/debian-xterm.desktop \
+    /usr/share/applications/footclient.desktop \
+    /usr/share/applications/foot-server.desktop \
+    /usr/share/applications/mate-about.desktop \
+    /usr/share/applications/mate-color-select.desktop \
+    /usr/share/applications/st.desktop \
+    /usr/share/applications/xfce4-terminal-settings.desktop \
     /var/lib/apt/lists/* \
-    /var/tmp/* \
-    /tmp/*
+    /var/tmp/*
 
 # add local files
 COPY /root /

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -10,7 +10,11 @@ LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DA
 LABEL maintainer="thelamer"
 
 # title
-ENV TITLE=Github-Desktop
+ENV TITLE=Github-Desktop \
+    NO_GAMEPAD=true \
+    NO_FULL=true \
+    SELKIES_DESKTOP=true \
+    PIXELFLUX_WAYLAND=true
 
 RUN \
   echo "**** add icon ****" && \
@@ -42,6 +46,9 @@ RUN \
     /tmp/codium.deb -L \
     "https://github.com/VSCodium/vscodium/releases/download/${CODIUM_VERSION}/codium_${CODIUM_VERSION}_arm64.deb" && \
   apt install --no-install-recommends -y /tmp/codium.deb && \
+  sed -i \
+    's:/usr/share/codium/codium:/usr/bin/codium:g' \
+    /usr/share/applications/codium.desktop && \
   echo "**** container tweaks ****" && \
   ln -s \
     /usr/bin/xfce4-terminal \
@@ -52,9 +59,24 @@ RUN \
   echo "**** cleanup ****" && \
   apt-get autoclean && \
   rm -rf \
+    /tmp/* \
+    /usr/share/applications/caja-autorun-software.desktop \
+    /usr/share/applications/caja-computer.desktop \
+    /usr/share/applications/caja.desktop \
+    /usr/share/applications/caja-file-management-properties.desktop \
+    /usr/share/applications/caja-folder-handler.desktop \
+    /usr/share/applications/caja-home.desktop \
+    /usr/share/applications/codium-url-handler.desktop \
+    /usr/share/applications/debian-uxterm.desktop \
+    /usr/share/applications/debian-xterm.desktop \
+    /usr/share/applications/footclient.desktop \
+    /usr/share/applications/foot-server.desktop \
+    /usr/share/applications/mate-about.desktop \
+    /usr/share/applications/mate-color-select.desktop \
+    /usr/share/applications/st.desktop \
+    /usr/share/applications/xfce4-terminal-settings.desktop \
     /var/lib/apt/lists/* \
-    /var/tmp/* \
-    /tmp/*
+    /var/tmp/*
 
 # add local files
 COPY /root /

--- a/README.md
+++ b/README.md
@@ -620,6 +620,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **03.04.26:** - Make Wayland default disable with PIXELFLUX_WAYLAND=false.
 * **21.03.26:** - Use Wayland ozone platform flag for apps fixes scaling and acceleration.
 * **28.12.25:** - Add Wayland init logic.
 * **22.09.25:** - Rebase to Debian Trixie.

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -107,6 +107,7 @@ init_diagram: |
   "github-desktop:latest" <- Base Images
 # changelog
 changelogs:
+  - {date: "03.04.26:", desc: "Make Wayland default disable with PIXELFLUX_WAYLAND=false."}
   - {date: "21.03.26:", desc: "Use Wayland ozone platform flag for apps fixes scaling and acceleration."}
   - {date: "28.12.25:", desc: "Add Wayland init logic."}
   - {date: "22.09.25:", desc: "Rebase to Debian Trixie."}

--- a/root/defaults/autostart_wayland
+++ b/root/defaults/autostart_wayland
@@ -1,3 +1,14 @@
 #! /bin/bash
-xdg-mime default caja.desktop inode/directory
+
+if [ ! -f "${HOME}/Desktop/github-desktop.desktop" ]; then
+  cp /usr/share/applications/github-desktop.desktop "${HOME}/Desktop/"
+  cp /usr/share/applications/chromium.desktop "${HOME}/Desktop/"
+  cp /usr/share/applications/codium.desktop "${HOME}/Desktop/"
+fi
+
+touch "${HOME}/.config/panel-reload"
+gio mime x-scheme-handler/http chromium.desktop
+gio mime x-scheme-handler/https chromium.desktop
+gio mime application/x-terminal-emulator foot.desktop
+
 dbus-launch github-desktop


### PR DESCRIPTION
Swapping to selkies desktop on this one for wayland as this application needs to interact with external stuff a lot. Added proper mime type handling. Need to keep xfce4-terminal in here to still have parity with X11 mode, but foot in general is a solid replacement and can be used. 